### PR TITLE
Various fixes and additions

### DIFF
--- a/bastion.js
+++ b/bastion.js
@@ -296,6 +296,12 @@ let commandList = [{
 	names: ["yugi", "yugipedia"],
 	func: yugi,
 	desc: "Links a given page from the Yugipedia wiki."
+},
+{
+	names: ["tfix", "triviafix", "fixtrivia"],
+	func: triviaFix,
+	chk: () => channelID in gameData,
+	desc: "Clears the trivia data for the current channel, fixing issues when it freezes."
 }];
 
 let helpCooldown = true;
@@ -2729,6 +2735,15 @@ function tlock(user, userID, channelID, message, event) {
 		}
 		sendMessage(user, userID, channelID, message, event, "Trivia locked to this channel!\nTrivia is locked to the following channels on this server: " + out.join(", ")).catch(msgErrHandler);
 		config.triviaLocks = triviaLocks;
+	}
+}
+
+function triviaFix(user, userID, channelID, message, event) {
+	if (channelID in gameData) {
+		console.log("User: " + user + " force quit trivia in #" + bot.channels[channelID].name + ". Game state:");
+		console.dir(gameData[channelID]);
+		delete gameData[channelID];
+		sendMessage(user, userID, channelID, message, event, "Trivia data cleared!");
 	}
 }
 

--- a/bastion.js
+++ b/bastion.js
@@ -2484,7 +2484,7 @@ async function startTriviaRound(round, hard, outLang, argObj, user, userID, chan
 		bot.uploadFile({
 			to: channelID,
 			file: buffer,
-			filename: code + "." + imageExt
+			filename: "triviaPic." + imageExt
 		}, err => {
 			if (err) {
 				console.error(err);

--- a/bastion.js
+++ b/bastion.js
@@ -298,6 +298,11 @@ let commandList = [{
 	desc: "Links a given page from the Yugipedia wiki."
 },
 {
+	names: ["ygoprodeck", "ydeck", "ygodeck", "prodeck"],
+	func: proDeck,
+	desc: "Links the YGOProDeck database page for a given card."
+},
+{
 	names: ["tfix", "triviafix", "fixtrivia"],
 	func: triviaFix,
 	chk: () => channelID in gameData,
@@ -1624,6 +1629,29 @@ function yugi(user, userID, channelID, message, event, name) {
 		}
 		sendMessage(user, userID, channelID, message, event, out).catch(msgErrHandler);
 	});
+}
+
+function proDeck(user, userID, channelID, message, event, name) {
+	let serverID = bot.channels[channelID] && bot.channels[channelID].guild_id;
+	let input = message.slice((config.getConfig("prefix", serverID) + name + " ").length);
+	let args = input.split("|");
+	let inLang = config.getConfig("defaultLanguage");
+	if (args.length > 1) {
+		input = args[0];
+		if (args[1] in dbs)
+			inLang = args[1];
+	}
+	let inInt = parseInt(input);
+	let code;
+	if (inInt in cards[inLang]) {
+		code = inInt;
+	} else {
+		code = nameCheck(input, inLang);
+	}
+	if (!(code && code in cards[inLang]))
+		return;
+	let name = cards[config.getConfig("defaultLanguage")][code].name;
+	sendMessage(user, userID, channelID, message, event, "https://db.ygoprodeck.com/card/?search=" + encodeURISegment(name));	
 }
 
 function setConf(user, userID, channelID, message, event) {

--- a/bastion.js
+++ b/bastion.js
@@ -2780,6 +2780,15 @@ function triviaFix(user, userID, channelID, message, event) {
 	if (channelID in gameData) {
 		console.log("User: " + user + " force quit trivia in #" + bot.channels[channelID].name + ". Game state:");
 		console.dir(gameData[channelID]);
+		if (gameData[channelID].TO1) {
+			clearTimeout(gameData[channelID].TO1);
+		}
+		if (gameData[channelID].TO2) {
+			clearTimeout(gameData[channelID].TO2);
+		}
+		if (gameData[channelID].IN) {
+			clearInterval(gameData[channelID].IN);
+		}
 		delete gameData[channelID];
 		sendMessage(user, userID, channelID, message, event, "Trivia data cleared!");
 	}

--- a/bastion.js
+++ b/bastion.js
@@ -305,7 +305,7 @@ let commandList = [{
 {
 	names: ["tfix", "triviafix", "fixtrivia"],
 	func: triviaFix,
-	chk: () => channelID in gameData,
+	chk: (user, userID, channelID) => channelID in gameData,
 	desc: "Clears the trivia data for the current channel, fixing issues when it freezes."
 }];
 
@@ -1650,8 +1650,8 @@ function proDeck(user, userID, channelID, message, event, name) {
 	}
 	if (!(code && code in cards[inLang]))
 		return;
-	let name = cards[config.getConfig("defaultLanguage")][code].name;
-	sendMessage(user, userID, channelID, message, event, "https://db.ygoprodeck.com/card/?search=" + encodeURISegment(name));	
+	let engName = cards[config.getConfig("defaultLanguage")][code].name;
+	sendMessage(user, userID, channelID, message, event, "https://db.ygoprodeck.com/card/?search=" + encodeURI(engName));	
 }
 
 function setConf(user, userID, channelID, message, event) {

--- a/bastion.js
+++ b/bastion.js
@@ -1996,6 +1996,16 @@ function parseFilterArgs(input) {
 			func: arg => !isNaN(parseInt(arg)),
 			convert: arg => parseInt(arg)
 		},
+		"rank": {
+			name: "level",
+			func: arg => !isNaN(parseInt(arg)),
+			convert: arg => parseInt(arg)
+		},
+		"link": {
+			name: "level",
+			func: arg => !isNaN(parseInt(arg)),
+			convert: arg => parseInt(arg)
+		},
 		"lscale": {
 			name: "lscale",
 			func: arg => !isNaN(parseInt(arg)),

--- a/bastion.js
+++ b/bastion.js
@@ -1422,7 +1422,7 @@ async function rulings(user, userID, channelID, message, event, name) {
 			} else {
 				let jaName = jaCard.name;
 				let jUrl = "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=1&sess=1&keyword=" + jaName + "&stype=1&ctype=&starfr=&starto=&pscalefr=&pscaleto=&linkmarkerfr=&linkmarkerto=&atkfr=&atkto=&deffr=&defto=&othercon=2&request_locale=ja";
-				out =+ "<" + encodeURI(jUrl) + ">\nClick the appropriate search result, then the yellow button that reads \"このカードのＱ＆Ａを表示\"";
+				out += "<" + encodeURI(jUrl) + ">\nClick the appropriate search result, then the yellow button that reads \"このカードのＱ＆Ａを表示\"";
 			}
 		} else {
 			out = e;

--- a/bastion.js
+++ b/bastion.js
@@ -1748,7 +1748,7 @@ async function sendCardProfile(user, userID, channelID, message, event, code, ou
 			});
 		}
 		embed.fields.forEach((_,i) => { //uses key instead of value to modify original array
-			if (embed.fields[i].value.length < 1) {
+			if (embed.fields[i].value.trim().length < 1) {
 				embed.fields[i].value = "[ no card text ]";
 			}
 		});


### PR DESCRIPTION
Adds command to quit trivia when it goes haywire, which serves as a workaround for Issue #31. 
Obscures the filename of trivia images, preventing cheating.
Adds a command to search the YGOPro Deck DB.
Fixes a stray "NaN" appearing in the rulings search when it uses the Japanese text backup.
Adds "Rank" and "Link" as aliases for "Level" when filtering cards.